### PR TITLE
Home feed locale fix

### DIFF
--- a/server/js/core/mappers/crunchyroll.js
+++ b/server/js/core/mappers/crunchyroll.js
@@ -86,15 +86,15 @@ window.mapper = {
   },
 
   load: (item, index, callback) => {
-    var url;
-    if (item.resource_type === "dynamic_collection") {
-      url = item.link;
-    } else {
-      url = `/content/v2/cms/objects/${item.ids.join()}?locale=es-419`;
-    }
-
     session.refresh({
       success: function (storage) {
+        var url;
+        if (item.resource_type === "dynamic_collection") {
+          url = item.link;
+        } else {
+          url = `/content/v2/cms/objects/${item.ids.join()}?locale=${storage.account.language}`;
+        }
+
         var headers = new Headers();
         headers.append("Authorization", `Bearer ${storage.access_token}`);
         headers.append("Content-Type", "application/x-www-form-urlencoded");

--- a/server/js/core/session.js
+++ b/server/js/core/session.js
@@ -141,14 +141,16 @@ window.session = {
     }
   },
 
-  load_account: function () {
+  load_account: function (callback) {
     service.profile({
       success: function (response) {
         session.storage.account.language =
           response.preferred_content_subtitle_language;
         session.storage.account.avatar = response.avatar;
         session.update();
+        callback.success();
       },
+      error: callback.error
     });
 
     session.cookies({

--- a/server/js/main.js
+++ b/server/js/main.js
@@ -18,8 +18,11 @@ window.main = {
     login: function () {
       session.valid({
         success: function () {
-          session.load_account();
-          main.events.home();
+          session.load_account({
+            success: function () {
+              main.events.home();
+            }
+          });
         },
         error: function (error) {
           console.log(error);


### PR DESCRIPTION
## [Switch hardcoded es-419 locale to account locale](https://github.com/jhassan8/crunchyroll-tizen/commit/b3b6d0635406becbdc478dc8c75d9cbd6c666807)

Some anime descriptions on the home feed are displayed in spanish independently of the account or TV selected locale.

## [Await account locale loaded before loading home](https://github.com/jhassan8/crunchyroll-tizen/commit/903c2e719abbbc05e7cf895f357a2b91274e1267)

Another query has the locale parameter set to NaN, as the home_feed is loaded before the acount locale could be fetched. This results in using the TV locale by default instead of the account locale.