### PR TITLE
Improved the search page

### DIFF
--- a/js/keys.js
+++ b/js/keys.js
@@ -35,6 +35,7 @@ window.tvKey = {
   KEY_BLUE: 406,
   KEY_MENU: 18,
   KEY_EXIT: 0,
+  KEY_ESCAPE: 27,
 };
 
 [

--- a/server/css/search.css
+++ b/server/css/search.css
@@ -50,30 +50,62 @@
 }
 
 #search-screen .content .list-container {
-  margin-top: 92px;
   overflow: hidden;
+  height: 100%;
+  position: relative;
+  padding-top: 80px;
+  margin-top: 5px;
 }
 
 #search-screen .content .list-container .list-container-over {
-  /* transition: margin 0.2s; */
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-gap: 30px;
+  /* transition: margin 100ms ease-out; */
+}
+
+#search-screen .content .list-container .list-container-over:before {
+  content: '';
+  width: 102vw;
+  left: -1vw;
+  height: 75px;
+  position: absolute;
+  z-index: 1;
+  background: linear-gradient(black, transparent);
+  top: 0;
+}
+
+#search-screen .content .list-container .list-container-over:after {
+  content: '';
+  position: fixed;
+  width: 100vw;
+  height: 75px;
+  bottom: 0;
+  left: 0;
+  background: linear-gradient(transparent, black);
 }
 
 #search-screen .content .list-container .list-container-over .item {
   background: rgba(100, 100, 100, 0.5);
-  width: 161px;
-  height: 245px;
   opacity: 0.5;
   position: relative;
-  float: left;
-  margin: 15px;
 }
 
-#search-screen .content .list-container .list-container-over .item:nth-child(9n) {
-  margin-right: 0;
-}
-
-#search-screen .content .list-container .list-container-over .item:nth-child(9n+1) {
-  margin-left: 0;
+#search-screen .content .list-container .list-container-over .item .title {
+  background: rgba(0, 0, 0, 0.75);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  text-align: center;
+  font-size: 1.5rem;
+  color: white;
+  
+  width: 100%;
+  height: 3.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 #search-screen .content .list-container .list-container-over .item img {
@@ -98,10 +130,8 @@
   left: 0;
   box-sizing: border-box;
   border: 3px solid rgb(114, 114, 114);
-  /* box-shadow: 0 0 25px 6px #727272, 0 0 15px 6px #727272 inset; */
 }
 
 #search-screen .content .list-container.focus .list-container-over .item.selected::after{
   border: 3px solid rgb(244, 130, 33, 0.9);
-  /* box-shadow: 0 0 25px 6px #f47521, 0 0 15px 6px #f47521 inset; */
 }


### PR DESCRIPTION
# Added the titles to the result grid

Added the title of the show to the search items

# Added a fade to black on the top and bottom of the result grid

Added a fade to black on the top and bottom to let users more easily know there is more to scroll :)

# moved result grid rendering from hardcoded 9 width to `display: grid` 

Instead of hardcoding the grid width it is now managed by `display: grid`. The number of items per row can now be adjusted by changing `search.items_per_row`

# abstracted scrolling and focus toggling to their own functions

Moved the scrolling/toggling of the focus to their own functions. Improves readability and saves some lines


 