### PR TITLE
Feat: Logout button

### DIFF
--- a/server/js/core/mappers/crunchyroll.js
+++ b/server/js/core/mappers/crunchyroll.js
@@ -27,6 +27,7 @@ window.mapper = {
       })),
     };
 
+    mapper.loaded = 0
     for (var index = 0; index < lists.length; index++) {
       mapper.load(lists[index], index, {
         success: function (test, on) {

--- a/server/js/main.js
+++ b/server/js/main.js
@@ -15,6 +15,19 @@ window.main = {
   },
 
   events: {
+    logout: function() {
+      if (document.getElementById(menu.id) != null) menu.destroy();
+
+      var current_id = main.state.replace("-screen", '')
+      if( window[current_id] === undefined ) {
+        console.log("Failed to find ID of current screen")
+        menu.init();
+        return;
+      }
+      if (document.getElementById(main.state) != null) window[current_id].destroy()
+      session.clear();
+      login.init();
+    },
     login: function () {
       session.valid({
         success: function () {

--- a/server/js/screen/menu.js
+++ b/server/js/screen/menu.js
@@ -1,32 +1,39 @@
 window.menu = {
   id: "menu-screen",
   options: [
-    {
-      id: "search",
-      label: "Search",
-      icon: "fa-solid fa-magnifying-glass",
-      action: 'search.init',
-    },
-    { id: "home", label: "Home", icon: "fa-solid fa-house", action: 'home.init' },
-    { id: "list", label: "My list", icon: "fa-solid fa-bookmark" },
-    { id: "historyScreen", label: "History", icon: "fa-solid fa-clock-rotate-left", action: 'historyScreen.init'},
-    { id: "browse", label: "Browse", icon: "fa-regular fa-rectangle-list" },
+    { id: "search",         label: "Search",    icon: "fa-solid fa-magnifying-glass",     action: 'search.init', },
+    { id: "home",           label: "Home",      icon: "fa-solid fa-house",                action: 'home.init' },
+    { id: "list",           label: "My list",   icon: "fa-solid fa-bookmark" },
+    { id: "historyScreen",  label: "History",   icon: "fa-solid fa-clock-rotate-left",    action: 'historyScreen.init' },
+    { id: "browse",         label: "Browse",    icon: "fa-regular fa-rectangle-list" },
+    { id: "settings",       label: "Settings",  icon: "fa-solid fa-gear",     tool: true },
+    { id: "logout",         label: "Logout",    icon: "fa-solid fa-sign-out", tool: true , event: "logout" },
   ],
   selected: 1,
   previous: NaN,
+  isOpen: false,
 
   init: function () {
     var menu_element = document.createElement("div");
     menu_element.id = this.id;
 
+    var tool_options = "";
     var menu_options = "";
 
     menu.options.forEach((element, index) => {
-      menu_options += `
-      <a class="option ${index === menu.selected ? "selected" : ""}">
-        <i class="${element.icon}"></i>
-        <p>${element.label}</p>
-      </a>`;
+      if(!!element.tool) {
+        tool_options += `
+        <a class="option ${index === menu.selected ? "selected" : ""}">
+          <i class="${element.icon}"></i>
+          <p>${element.label}</p>
+        </a>`;
+      } else {
+        menu_options += `
+        <a class="option ${index === menu.selected ? "selected" : ""}">
+          <i class="${element.icon}"></i>
+          <p>${element.label}</p>
+        </a>`;
+      }
     });
 
     menu_element.innerHTML = `
@@ -44,10 +51,7 @@ window.menu = {
         ${menu_options}
       </div>
       <div class="tools">
-        <a class="option">
-          <i class="fa-solid fa-gear"></i>
-          <p>Settings</p>
-        </a>
+        ${tool_options}
       </div>
     </div>`;
 
@@ -55,11 +59,14 @@ window.menu = {
   },
 
   destroy: function () {
+    if(menu.isOpen) {
+      menu.close()
+    }
     document.body.removeChild(document.getElementById(this.id));
-    main.state = this.previous;
   },
 
   open: function () {
+    menu.isOpen = true
     $("body").addClass("open-menu");
     $(`#${menu.id} .option.selected`).addClass("focus");
     this.previous = main.state;
@@ -67,6 +74,7 @@ window.menu = {
   },
 
   close: function () {
+    menu.isOpen = false
     $("body").removeClass("open-menu");
     $(`#${menu.id} .option`).removeClass("focus");
     main.state = this.previous;
@@ -94,7 +102,7 @@ window.menu = {
         menu.close();
         break;
       case tvKey.KEY_BACK:
-      case 27:
+      case tvKey.KEY_ESCAPE:
         exit.init();
         break;
       case tvKey.KEY_UP:
@@ -124,6 +132,8 @@ window.menu = {
           test = menu.options[current].action.split('.');
           window[test[0]][test[1]]()
           menu.close();
+        } else if (menu.options[current].event) {
+          window.main.events[menu.options[current].event]()
         }
         break;
     }


### PR DESCRIPTION
Add a logout button in de menu.

This is helpful when a user has changed their password or when loading the user's profile did not 100% work.

May be a good idea to link the logout event (not directly) to the 401 API error.

On of the things I'm not really sure about is the way I call destroy on the current view. At the moment I get the current view by replacing the `-screen` from the state. Is there any better way to do this?
```js
  logout: function() {
      if (document.getElementById(menu.id) != null) menu.destroy();

      var current_id = main.state.replace("-screen", '')
      if( window[current_id] === undefined ) {
        console.log("Failed to find ID of current screen")
        menu.init();
        return;
      }
      if (document.getElementById(main.state) != null) window[current_id].destroy()
      session.clear();
      login.init();
    },
```

