### PR TITLE
feat: add linux electron build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 .mockoon
 
 dist
+electron/static/build/
 node_modules/
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 #### Complete
 - [x] Auth workflow
+- [x] Profiles screen
 - [x] Home screen
 - [x] Details screen
 - [x] Episodes screen
@@ -59,3 +60,15 @@
 3. In project folder run:
     - online: ```npm run start-tv-online --tv=<name_of_tv_device_manager>```
     - offline: ```npm run start-tv --tv=<name_of_tv_device_manager>```
+
+## Linux App (experimental)
+
+required: npm
+
+## Development
+
+run `npm run electron-run`. Note that there is no hot reloading, so the command must be rerun to see updated changes
+
+## Build
+
+run `npm run electron-build`. This will create an AppImage in the `electron/dist` directory.

--- a/electron/index.js
+++ b/electron/index.js
@@ -1,0 +1,42 @@
+const { app, components, BrowserWindow } = require("electron");
+
+function createWindow() {
+  const win = new BrowserWindow({
+    fullscreen: true,
+    autoHideMenuBar: true,
+    webPreferences: {
+      nodeIntegration: false,
+      webSecurity: false,
+      contextIsolation: true,
+    },
+  });
+  // disable alt for menu bar
+  win.setMenu(null);
+
+  const userAgent =
+    "Mozilla/5.0 (SMART-TV; LINUX; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/5.0 TV Safari/537.36";
+
+  win.webContents.setUserAgent(userAgent);
+
+  win.loadFile("./static/build/index.html", {
+    userAgent:
+      "Mozilla/5.0 (SMART-TV; LINUX; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/5.0 TV Safari/537.36",
+  });
+}
+
+app.whenReady().then(async () => {
+  await components.whenReady();
+  createWindow();
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
+});
+
+app.on("activate", () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "Crunchyroll",
+  "version": "1.0.0",
+  "description": "Crunchyroll client that uses the TV interface",
+  "main": "index.js",
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder"
+  },
+  "build": {
+    "appId": "com.crunchyroll",
+    "electronDownload": {
+      "mirror": "https://github.com/castlabs/electron-releases/releases/download/v"
+    },
+    "productName": "Crunchyroll",
+    "files": [
+      "index.js",
+      "package.json",
+      "static/**/*"
+    ],
+    "linux": {
+      "target": [
+        "AppImage"
+      ],
+      "artifactName": "${productName}_v${version}_linux.${ext}",
+      "category": "Utility"
+    }
+  },
+  "keywords": [],
+  "devDependencies": {
+    "electron": "github:castlabs/electron-releases#v31.3.0+wvcus",
+    "electron-builder": "^24.13.3"
+  }
+}

--- a/electron_build.sh
+++ b/electron_build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -rf electron/static
+
+mkdir -p electron/static/build
+cp ./index.html electron/static/build
+cp -rf server/ electron/static/build
+cp -rf img/ electron/static/build
+cp -rf js/ electron/static/build
+cp -rf css/ electron/static/build

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build-cdn": "grunt cdn",
     "deploy": "npm run build-cdn && gh-pages -d dist -b cdn",
+    "electron-run": "sh ./electron_build.sh && cd electron && npm install && npm run start",
+    "electron-build": "sh ./electron_build.sh && cd electron && npm install && npm run build",
     "run": "npm run tizen-start --tv=LS27AM500NLXZB --tv2=UN65MU6100",
     "tizen-build": "grunt offline-tizen",
     "tizen-build-online": "grunt online-tizen",


### PR DESCRIPTION
This enables an electron build that generates an AppImage for Linux.

Feel free to close this PR if you don't plan on supporting Desktop usage.